### PR TITLE
Add Cloud-Init VM creation script

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,5 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Install yq
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.6/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
       - name: Run secret pattern check
         run: bash scripts/validate/check-no-secrets.sh
+      - name: Check shell syntax
+        run: |
+          bash -n scripts/lib/vm-cloudinit-config.sh
+          bash -n scripts/pve/create-cloudinit-vm.sh
+          bash -n scripts/validate/check-vm-cloudinit-config.sh
+      - name: Validate VM Cloud-Init example config
+        run: bash scripts/validate/check-vm-cloudinit-config.sh inventory/vms/examples/cloudinit-vm.example.yaml
+      - name: Dry-run VM Cloud-Init create script
+        run: bash scripts/pve/create-cloudinit-vm.sh --config inventory/vms/examples/cloudinit-vm.example.yaml

--- a/docs/05-runbooks/create-cloudinit-vm.md
+++ b/docs/05-runbooks/create-cloudinit-vm.md
@@ -1,0 +1,150 @@
+# Cloud-Init VM 创建 Runbook
+
+## 目标
+
+使用 `scripts/pve/create-cloudinit-vm.sh` 从既有 Proxmox Cloud-Init Template 创建单台 VM，并把 VM 参数保存在 YAML 配置中。
+
+## 适用范围
+
+- PVE host：`pve-01`
+- 模板来源：Debian Cloud Image + Cloud-Init VM Template
+- 创建方式：`qm clone` + `qm set` + `qm cloudinit update`
+- 配置文件：YAML
+
+第一版只支持创建单台 VM，不支持批量创建、Terraform、DNS/反代/防火墙自动配置或 guest 内二次初始化。
+
+## 前置条件
+
+在 PVE host 上确认：
+
+```bash
+command -v qm
+command -v yq
+command -v ssh-keygen
+qm status <template-vmid>
+```
+
+要求：
+
+- Cloud-Init template 已完成 `cloud-init clean` 和 machine-id 清理。
+- Template 已转换为 PVE template。
+- SSH public key 文件存在，只使用公钥登录。
+- 目标 VMID 未被占用。
+- 目标 IP 已在 `inventory/ips.md` / `inventory/hosts.md` 中规划或确认不冲突。
+
+## 配置文件
+
+从示例复制：
+
+```bash
+cp inventory/vms/examples/cloudinit-vm.example.yaml inventory/vms/vm-k8s-01.yaml
+```
+
+字段说明：
+
+```yaml
+vm:
+  template_vmid: 9000        # PVE Cloud-Init template VMID
+  vmid: 1050                 # 新 VMID
+  name: vm-example-01        # 新 VM 名称
+  storage: local-lvm         # 可选，clone 目标 storage
+  cores: 2
+  memory_mb: 2048
+  disk: 30G                  # 可选，创建后 resize scsi0
+  network:
+    bridge: vmbr0
+    ip: 192.168.5.250/24
+    gateway: 192.168.5.1
+  cloudinit:
+    user: debian
+    ssh_public_key_file: ~/.ssh/id_ed25519.pub
+  start: false               # true 时创建后启动
+```
+
+示例配置使用 `inventory/vms/examples/example.pub` 作为非敏感示例公钥；真实 VM 配置应改成你的运维公钥路径。
+
+## 校验配置
+
+```bash
+bash scripts/validate/check-vm-cloudinit-config.sh inventory/vms/vm-k8s-01.yaml
+```
+
+校验内容：
+
+- YAML 可解析。
+- 必填字段存在。
+- VMID/CPU/RAM 是数字。
+- VMID 与 template VMID 不相同。
+- VM 名称符合 hostname 风格。
+- IP 使用 CIDR 格式，gateway 使用 IPv4 格式。
+- SSH public key 文件存在且可被 `ssh-keygen` 识别。
+- 与 `inventory/hosts.md` / `inventory/ips.md` 中已有 name/IP 做冲突提示。
+
+## Dry-run
+
+默认不执行 `qm`，只打印命令：
+
+```bash
+bash scripts/pve/create-cloudinit-vm.sh --config inventory/vms/vm-k8s-01.yaml
+```
+
+检查输出顺序应为：
+
+1. `qm clone`
+2. `qm set --cores --memory`
+3. `qm set --net0`
+4. `qm set --ciuser --sshkeys`
+5. `qm set --ipconfig0`
+6. `qm resize`（如果设置了 `disk`）
+7. `qm cloudinit update`
+8. `qm start`（如果 `start: true`）
+
+## Apply 创建 VM
+
+确认 dry-run 输出无误后执行：
+
+```bash
+bash scripts/pve/create-cloudinit-vm.sh --config inventory/vms/vm-k8s-01.yaml --apply
+```
+
+脚本会在 apply 前检查目标 VMID 是否已存在。若中途失败，脚本不会自动 destroy VM，需要操作者手动判断是否清理。
+
+## 创建后验证
+
+```bash
+qm status <vmid>
+qm config <vmid>
+```
+
+如果 `start: true`：
+
+```bash
+qm terminal <vmid>
+ssh <ci-user>@<vm-ip>
+```
+
+在 guest 内确认 Cloud-Init 完成：
+
+```bash
+cloud-init status --wait
+ip addr
+hostnamectl
+```
+
+## 回滚 / 清理
+
+如果创建失败或配置错误，先确认 VM 是否承载了任何需要保留的数据。确认可删除后：
+
+```bash
+qm stop <vmid>
+qm destroy <vmid> --purge 1
+```
+
+不要让脚本自动执行 destroy；VM 删除必须由操作者显式确认。
+
+## 与项目文档的关系
+
+- 设计决策：`docs/06-decisions/adr-0003-cloud-init-vm-template.md`
+- IP 规划：`inventory/ips.md`
+- Host 台账：`inventory/hosts.md`
+- 示例配置：`inventory/vms/examples/cloudinit-vm.example.yaml`

--- a/inventory/vms/examples/cloudinit-vm.example.yaml
+++ b/inventory/vms/examples/cloudinit-vm.example.yaml
@@ -1,0 +1,16 @@
+vm:
+  template_vmid: 9000
+  vmid: 1050
+  name: vm-example-01
+  storage: local-lvm
+  cores: 2
+  memory_mb: 2048
+  disk: 30G
+  network:
+    bridge: vmbr0
+    ip: 192.168.5.250/24
+    gateway: 192.168.5.1
+  cloudinit:
+    user: debian
+    ssh_public_key_file: inventory/vms/examples/example.pub
+  start: false

--- a/inventory/vms/examples/example.pub
+++ b/inventory/vms/examples/example.pub
@@ -1,0 +1,1 @@
+ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIJeHxKFo5aObp3YVyJRythr2Pvrnh+1niJs1Ej8fgCrU homelab-example-only

--- a/scripts/lib/vm-cloudinit-config.sh
+++ b/scripts/lib/vm-cloudinit-config.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+
+vmcfg_fail() {
+  echo "[fail] $*" >&2
+  exit 1
+}
+
+vmcfg_warn() {
+  echo "[warn] $*" >&2
+}
+
+vmcfg_require_cmd() {
+  command -v "$1" >/dev/null 2>&1 || vmcfg_fail "missing required command: $1"
+}
+
+vmcfg_yq_read() {
+  yq -r "$1 // \"\"" "$VMCFG_CONFIG"
+}
+
+vmcfg_is_uint() {
+  [[ "$1" =~ ^[0-9]+$ ]]
+}
+
+vmcfg_validate_hostname() {
+  local value="$1"
+  [[ "$value" =~ ^[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?$ ]]
+}
+
+vmcfg_validate_cidr_ipv4() {
+  local value="$1" ip
+  [[ "$value" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}/([0-9]|[12][0-9]|3[0-2])$ ]] || return 1
+  ip="${value%/*}"
+  vmcfg_validate_ipv4 "$ip"
+}
+
+vmcfg_validate_ipv4() {
+  local value="$1" octet
+  local -a octets
+  [[ "$value" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]] || return 1
+  IFS='.' read -r -a octets <<< "$value"
+  for octet in "${octets[@]}"; do
+    (( 10#$octet <= 255 )) || return 1
+  done
+}
+
+vmcfg_expand_path() {
+  local path="$1"
+  if [[ "$path" == ~/* ]]; then
+    printf '%s/%s\n' "$HOME" "${path#~/}"
+  else
+    printf '%s\n' "$path"
+  fi
+}
+
+vmcfg_check_inventory_conflict() {
+  local field="$1"
+  local value="$2"
+  local expected_name="$3"
+  local files=(inventory/hosts.md inventory/ips.md)
+  local file line
+
+  for file in "${files[@]}"; do
+    [[ -f "$file" ]] || continue
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      if [[ "$line" != *"$expected_name"* ]]; then
+        vmcfg_warn "$field '$value' appears in $file but not on a line containing '$expected_name'"
+        vmcfg_warn "  $line"
+      fi
+    done < <(grep -F "$value" "$file" || true)
+  done
+}
+
+vmcfg_load() {
+  VMCFG_CONFIG="$1"
+  [[ -f "$VMCFG_CONFIG" ]] || vmcfg_fail "config file not found: $VMCFG_CONFIG"
+
+  vmcfg_require_cmd yq
+  vmcfg_require_cmd ssh-keygen
+  yq '.' "$VMCFG_CONFIG" >/dev/null
+
+  TEMPLATE_VMID="$(vmcfg_yq_read '.vm.template_vmid')"
+  VMID="$(vmcfg_yq_read '.vm.vmid')"
+  NAME="$(vmcfg_yq_read '.vm.name')"
+  STORAGE="$(vmcfg_yq_read '.vm.storage')"
+  CORES="$(vmcfg_yq_read '.vm.cores')"
+  MEMORY_MB="$(vmcfg_yq_read '.vm.memory_mb')"
+  DISK="$(vmcfg_yq_read '.vm.disk')"
+  BRIDGE="$(vmcfg_yq_read '.vm.network.bridge')"
+  IP="$(vmcfg_yq_read '.vm.network.ip')"
+  GATEWAY="$(vmcfg_yq_read '.vm.network.gateway')"
+  CI_USER="$(vmcfg_yq_read '.vm.cloudinit.user')"
+  SSH_PUBLIC_KEY_FILE="$(vmcfg_yq_read '.vm.cloudinit.ssh_public_key_file')"
+  START="$(vmcfg_yq_read '.vm.start')"
+  [[ -n "$START" ]] || START="false"
+
+  for pair in \
+    "vm.template_vmid:$TEMPLATE_VMID" \
+    "vm.vmid:$VMID" \
+    "vm.name:$NAME" \
+    "vm.cores:$CORES" \
+    "vm.memory_mb:$MEMORY_MB" \
+    "vm.network.bridge:$BRIDGE" \
+    "vm.network.ip:$IP" \
+    "vm.network.gateway:$GATEWAY" \
+    "vm.cloudinit.user:$CI_USER" \
+    "vm.cloudinit.ssh_public_key_file:$SSH_PUBLIC_KEY_FILE"; do
+    local key="${pair%%:*}"
+    local value="${pair#*:}"
+    [[ -n "$value" ]] || vmcfg_fail "missing required field: $key"
+  done
+
+  vmcfg_is_uint "$TEMPLATE_VMID" || vmcfg_fail "vm.template_vmid must be numeric"
+  vmcfg_is_uint "$VMID" || vmcfg_fail "vm.vmid must be numeric"
+  [[ "$TEMPLATE_VMID" != "$VMID" ]] || vmcfg_fail "vm.vmid must differ from vm.template_vmid"
+  vmcfg_is_uint "$CORES" || vmcfg_fail "vm.cores must be numeric"
+  vmcfg_is_uint "$MEMORY_MB" || vmcfg_fail "vm.memory_mb must be numeric"
+  vmcfg_validate_hostname "$NAME" || vmcfg_fail "vm.name must be hostname-like"
+  vmcfg_validate_cidr_ipv4 "$IP" || vmcfg_fail "vm.network.ip must be IPv4 CIDR, e.g. 192.168.5.50/24"
+  vmcfg_validate_ipv4 "$GATEWAY" || vmcfg_fail "vm.network.gateway must be IPv4, e.g. 192.168.5.1"
+  vmcfg_validate_hostname "$CI_USER" || vmcfg_fail "vm.cloudinit.user must be username-like"
+
+  if [[ -n "$DISK" && ! "$DISK" =~ ^[0-9]+[GM]$ ]]; then
+    vmcfg_fail "vm.disk must look like 30G or 1024M"
+  fi
+
+  if [[ "$START" != "true" && "$START" != "false" ]]; then
+    vmcfg_fail "vm.start must be true or false"
+  fi
+
+  SSH_PUBLIC_KEY_FILE_EXPANDED="$(vmcfg_expand_path "$SSH_PUBLIC_KEY_FILE")"
+  [[ -f "$SSH_PUBLIC_KEY_FILE_EXPANDED" ]] || vmcfg_fail "SSH public key file not found: $SSH_PUBLIC_KEY_FILE"
+  ssh-keygen -l -f "$SSH_PUBLIC_KEY_FILE_EXPANDED" >/dev/null || vmcfg_fail "invalid SSH public key: $SSH_PUBLIC_KEY_FILE"
+
+  vmcfg_check_inventory_conflict "VM name" "$NAME" "$NAME"
+  vmcfg_check_inventory_conflict "IP" "${IP%%/*}" "$NAME"
+}

--- a/scripts/pve/create-cloudinit-vm.sh
+++ b/scripts/pve/create-cloudinit-vm.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/vm-cloudinit-config.sh
+source "$SCRIPT_DIR/../lib/vm-cloudinit-config.sh"
+
+APPLY=0
+CONFIG=""
+
+usage() {
+  cat <<'EOF'
+Usage: create-cloudinit-vm.sh --config <config.yaml> [--apply]
+
+Creates one Proxmox VM from a Cloud-Init template described by YAML.
+Default mode is dry-run: commands are printed but not executed.
+
+Required YAML shape:
+  vm:
+    template_vmid: 9000
+    vmid: 1050
+    name: vm-example-01
+    storage: local-lvm        # optional clone target storage
+    cores: 2
+    memory_mb: 2048
+    disk: 30G                 # optional resize target
+    network:
+      bridge: vmbr0
+      ip: 192.168.5.250/24
+      gateway: 192.168.5.1
+    cloudinit:
+      user: debian
+      ssh_public_key_file: inventory/vms/examples/example.pub
+    start: false
+EOF
+}
+
+info() {
+  echo "[info] $*"
+}
+
+quote_cmd() {
+  printf '%q' "$1"
+}
+
+print_command() {
+  local first=1 arg
+  for arg in "$@"; do
+    if [[ "$first" -eq 1 ]]; then
+      first=0
+    else
+      printf ' '
+    fi
+    quote_cmd "$arg"
+  done
+  printf '\n'
+}
+
+run_command() {
+  print_command "$@"
+  if [[ "$APPLY" -eq 1 ]]; then
+    "$@"
+  fi
+}
+
+parse_args() {
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --config)
+        [[ $# -ge 2 ]] || vmcfg_fail "--config requires a path"
+        CONFIG="$2"
+        shift 2
+        ;;
+      --apply)
+        APPLY=1
+        shift
+        ;;
+      --dry-run)
+        APPLY=0
+        shift
+        ;;
+      --help|-h)
+        usage
+        exit 0
+        ;;
+      *)
+        vmcfg_fail "unknown argument: $1"
+        ;;
+    esac
+  done
+
+  [[ -n "$CONFIG" ]] || vmcfg_fail "--config is required"
+}
+
+validate_apply_environment() {
+  if [[ "$APPLY" -eq 0 ]]; then
+    info "dry-run mode; add --apply to execute these commands"
+    return
+  fi
+
+  vmcfg_require_cmd qm
+  if qm status "$VMID" >/dev/null 2>&1; then
+    vmcfg_fail "VMID already exists: $VMID"
+  fi
+}
+
+build_and_run() {
+  local clone_cmd=(qm clone "$TEMPLATE_VMID" "$VMID" --name "$NAME" --full 1)
+  if [[ -n "$STORAGE" ]]; then
+    clone_cmd+=(--storage "$STORAGE")
+  fi
+
+  run_command "${clone_cmd[@]}"
+  run_command qm set "$VMID" --cores "$CORES" --memory "$MEMORY_MB"
+  run_command qm set "$VMID" --net0 "virtio,bridge=$BRIDGE"
+  run_command qm set "$VMID" --ciuser "$CI_USER" --sshkeys "$SSH_PUBLIC_KEY_FILE_EXPANDED"
+  run_command qm set "$VMID" --ipconfig0 "ip=$IP,gw=$GATEWAY"
+
+  if [[ -n "$DISK" ]]; then
+    run_command qm resize "$VMID" scsi0 "$DISK"
+  fi
+
+  run_command qm cloudinit update "$VMID"
+
+  if [[ "$START" == "true" ]]; then
+    run_command qm start "$VMID"
+  fi
+}
+
+main() {
+  parse_args "$@"
+  vmcfg_load "$CONFIG"
+  validate_apply_environment
+  build_and_run
+
+  if [[ "$APPLY" -eq 1 ]]; then
+    info "VM creation commands completed for $NAME ($VMID)"
+    info "Next checks: qm config $VMID; qm status $VMID; SSH to $CI_USER@${IP%%/*} after Cloud-Init finishes"
+  else
+    info "dry-run complete; no VM was created"
+  fi
+}
+
+main "$@"

--- a/scripts/validate/check-vm-cloudinit-config.sh
+++ b/scripts/validate/check-vm-cloudinit-config.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../lib/vm-cloudinit-config.sh
+source "$SCRIPT_DIR/../lib/vm-cloudinit-config.sh"
+
+usage() {
+  cat <<'EOF'
+Usage: check-vm-cloudinit-config.sh <config.yaml>
+
+Validates the YAML schema for one Proxmox Cloud-Init VM config.
+Requires yq v4.
+EOF
+}
+
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+
+[[ $# -eq 1 ]] || { usage >&2; exit 2; }
+
+vmcfg_load "$1"
+echo "[ok] VM Cloud-Init config is valid: $1"


### PR DESCRIPTION
## Summary
- Add YAML-backed validation for one Proxmox Cloud-Init VM config.
- Add a dry-run-by-default VM creation script using `qm clone`, `qm set`, and `qm cloudinit update`.
- Document the VM creation workflow and extend CI validation for the new scripts and example config.

## Test plan
- [x] `bash -n scripts/lib/vm-cloudinit-config.sh && bash -n scripts/pve/create-cloudinit-vm.sh && bash -n scripts/validate/check-vm-cloudinit-config.sh`
- [x] `bash scripts/validate/check-no-secrets.sh`
- [x] `PATH="/tmp:$PATH" bash scripts/validate/check-vm-cloudinit-config.sh inventory/vms/examples/cloudinit-vm.example.yaml`
- [x] `PATH="/tmp:$PATH" bash scripts/pve/create-cloudinit-vm.sh --config inventory/vms/examples/cloudinit-vm.example.yaml`
- [x] `scripts/pve/create-cloudinit-vm.sh --help && scripts/validate/check-vm-cloudinit-config.sh --help`
- [ ] Run `--apply` on the Proxmox host with a real VM config and verify `qm status`, `qm config`, SSH access, and `cloud-init status --wait`.